### PR TITLE
RNMT-2945 [Calendar Plugin] - Crash when opening calendar without date

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -696,18 +696,21 @@ public class Calendar extends CordovaPlugin {
       if (resultCode == Activity.RESULT_OK || resultCode == Activity.RESULT_CANCELED) {
         // resultCode may be 0 (RESULT_CANCELED) even when it was created, so passing nothing is the clearest option here
         Log.d(LOG_TAG, "onActivityResult resultcode: " + resultCode);
-        callback.success();
+        if (callback != null)
+          callback.success();
       } else {
         // odd case
         Log.d(LOG_TAG, "onActivityResult weird resultcode: " + resultCode);
-        callback.success();
+        if (callback != null)
+          callback.success();
       }
     } else if (requestCode == RESULT_CODE_OPENCAL) {
       Log.d(LOG_TAG, "onActivityResult requestCode: " + RESULT_CODE_OPENCAL);
-      callback.success();
+      // Callback is called right after startActivityForResult
     } else {
       Log.d(LOG_TAG, "onActivityResult error, resultcode: " + resultCode);
-      callback.error("Unable to add event (" + resultCode + ").");
+      if (callback != null)
+        callback.error("Unable to add event (" + resultCode + ").");
     }
   }
 

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -213,7 +213,8 @@ public class Calendar extends CordovaPlugin {
 
   private void openCalendarLegacy(JSONArray args) {
     try {
-      final Long millis = args.getJSONObject(0).optLong("date");
+      long provided = args.getJSONObject(0).optLong("date", -1);
+      final long millis = provided < 0 ? new Date().getTime() : provided;
 
       cordova.getThreadPool().execute(new Runnable() {
         @Override
@@ -236,7 +237,8 @@ public class Calendar extends CordovaPlugin {
   @TargetApi(14)
   private void openCalendar(JSONArray args) {
     try {
-      final Long millis = args.getJSONObject(0).optLong("date");
+      long provided = args.getJSONObject(0).optLong("date", -1);
+      final long millis = provided < 0 ? new Date().getTime() : provided;
 
       cordova.getThreadPool().execute(new Runnable() {
         @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed a crash when opening calendar without providing a date.
Fixed crashes when returning to app if activity got destroyed.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-2945

<!--- Why is this change required? What problem does it solve? -->
When opening the calendar in Android without providing a date the app crashes.

Additionally, if the activity is destroyed, methods that open native screens (open calendar; create event with dialog) crash when calling the callback.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests were performed.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly