### PR TITLE
RMET-292 CalendarPlugin - Event with invalid dates is created successfully

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -557,6 +557,11 @@ public class Calendar extends CordovaPlugin {
       final JSONObject argObject = args.getJSONObject(0);
       final JSONObject argOptionsObject = argObject.getJSONObject("options");
 
+      if(argObject.getLong("startTime") > argObject.getLong("endTime")){
+        callback.error("The start date must be before the end date");
+        return;
+      }
+
       cordova.getThreadPool().execute(new Runnable() {
         @Override
         public void run() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a verification to check if the start date of the event is after the end date. If this is the case, an error message will be returned in the callback and the event will not be created.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-292


<!--- Why is this change required? What problem does it solve? -->
When trying to create an event with a start date after the end date, we were getting a success feedback card.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested the changes locally with different dates:

- Tested with pairs (startDate, endDate) that should not be accepted (startDate > endDate). 

- Tested with pairs (startDate, endDate) that should be accepted, and the event should be created (startDate >= endDate).

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly