### PR TITLE
RMET-365 Calendar Plugin - Incorrect calendar date opening

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -474,10 +474,19 @@
   NSNumber* date = [options objectForKey:@"date"];
 
   [self.commandDelegate runInBackground: ^{
+    NSDate *openDate;
     NSTimeInterval _startInterval = [date doubleValue] / 1000; // strip millis
-    NSDate *openDate = [NSDate dateWithTimeIntervalSince1970:_startInterval];
+      
+    //date comes with negative value, corresponds to either empty date field or dates below 1970, use current date
+    if ([date doubleValue] < 0){
+      openDate = [NSDate date];
+    }
+    else if ([date doubleValue] > 0){
+     openDate = [NSDate dateWithTimeIntervalSince1970:_startInterval];
+    }
+      
     NSInteger interval = [openDate timeIntervalSinceReferenceDate];
-
+      
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"calshow:%ld", interval]];
     [[UIApplication sharedApplication] openURL:url];
   }];


### PR DESCRIPTION
References: https://outsystemsrd.atlassian.net/browse/RMET-365
Note: When date field is left empty, the date used will be 1900:00:00, which is a negative timestamp.

## Description
<!--- Describe your changes in detail -->
Added code to check if the timestamp corresponding to the date is negative (when date field is empty). If if is, the current date will be used.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-365

<!--- Why is this change required? What problem does it solve? -->
When date field was empty, the calendar was opening in an incorrect date (1932), not the current date.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested in real device locally (Android 11).

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly