### PR TITLE
RMET-328 Calendar Plugin - Incorrect notes when finding event

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -394,7 +394,7 @@
     }
     if (event.notes != nil || event.URL != nil) {
       NSString *notes = event.notes ?: @"";
-      NSString *url = (NSString*)event.URL ?: @"";
+      NSString *url = event.URL.absoluteString ?: @"";
       NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", notes, url];
       NSString *trimmed = [notesWithURL stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
       [entry setObject:trimmed forKey:@"message"];

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -392,8 +392,8 @@
     if (event.location != nil) {
       [entry setObject:event.location forKey:@"location"];
     }
-    NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", event.notes, event.URL];
-    if (event.notes != nil) {
+    if (event.notes != nil && event.URL != nil) {
+      NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", event.notes, event.URL];
       [entry setObject:notesWithURL forKey:@"message"];
     }
     if (event.attendees != nil) {

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -392,8 +392,9 @@
     if (event.location != nil) {
       [entry setObject:event.location forKey:@"location"];
     }
+    NSString *notesWithURL = [NSString stringWithFormat:@"%@%@", event.notes, event.URL];
     if (event.notes != nil) {
-      [entry setObject:event.notes forKey:@"message"];
+      [entry setObject:notesWithURL forKey:@"message"];
     }
     if (event.attendees != nil) {
       NSMutableArray * attendees = [[NSMutableArray alloc] init];

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -392,9 +392,12 @@
     if (event.location != nil) {
       [entry setObject:event.location forKey:@"location"];
     }
-    if (event.notes != nil && event.URL != nil) {
-      NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", event.notes, event.URL];
-      [entry setObject:notesWithURL forKey:@"message"];
+    if (event.notes != nil || event.URL != nil) {
+      NSString *notes = event.notes ?: @"";
+      NSString *url = (NSString*)event.URL ?: @"";
+      NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", notes, url];
+      NSString *trimmed = [notesWithURL stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+      [entry setObject:trimmed forKey:@"message"];
     }
     if (event.attendees != nil) {
       NSMutableArray * attendees = [[NSMutableArray alloc] init];

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -392,7 +392,7 @@
     if (event.location != nil) {
       [entry setObject:event.location forKey:@"location"];
     }
-    NSString *notesWithURL = [NSString stringWithFormat:@"%@%@", event.notes, event.URL];
+    NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", event.notes, event.URL];
     if (event.notes != nil) {
       [entry setObject:notesWithURL forKey:@"message"];
     }

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -393,11 +393,14 @@
       [entry setObject:event.location forKey:@"location"];
     }
     if (event.notes != nil || event.URL != nil) {
-      NSString *notes = event.notes ?: @"";
-      NSString *url = event.URL.absoluteString ?: @"";
-      NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", notes, url];
-      NSString *trimmed = [notesWithURL stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-      [entry setObject:trimmed forKey:@"message"];
+        NSString *notes = event.notes ?: @"";
+        NSString *url = @"";
+        if(event.URL != nil) {
+            url = event.URL.absoluteString;
+        }
+        NSString *notesWithURL = [NSString stringWithFormat:@"%@ %@", notes, url];
+        NSString *trimmed = [notesWithURL stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        [entry setObject:trimmed forKey:@"message"];
     }
     if (event.attendees != nil) {
       NSMutableArray * attendees = [[NSMutableArray alloc] init];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When finding an event in iOS (FindEvent screen) the notes did not include the URL data. Added the URL data to the notes.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-328

<!--- Why is this change required? What problem does it solve? -->
Notes did not include the URL, and a test was failing.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally (real device) and in Sauce Labs.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly