### PR TITLE
RMET-1201 Calendar Plugin - Fix crash for iOS >= 15

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -753,12 +753,12 @@
 
     self.interactiveCallbackId = command.callbackId;
 
-    EKEventEditViewController* controller = [[EKEventEditViewController alloc] init];
-    controller.event = myEvent;
-    controller.eventStore = self.eventStore;
-    controller.editViewDelegate = self;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.viewController presentViewController:controller animated:YES completion:nil];
+      EKEventEditViewController* controller = [[EKEventEditViewController alloc] init];
+      controller.event = myEvent;
+      controller.eventStore = self.eventStore;
+      controller.editViewDelegate = self;
+      [self.viewController presentViewController:controller animated:YES completion:nil];
     });
   }];
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We discovered that the plugin was causing a crash for iOS >= 15.1 because of the code that was now moved inside the dispatch_async. 

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
<!--- Why is this change required? What problem does it solve? -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1201

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally in XCode with iOS 15.2.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly