### PR TITLE
RMET-2726 ::: Add Support for iOS 17

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,10 @@
     <config-file target="*-Info.plist" parent="NSCalendarsUsageDescription">
       <string>$CALENDAR_USAGE_DESCRIPTION</string>
     </config-file>
+    <!-- Usage description for Full Access of the Calendar, available since iOS 17 -->
+    <config-file target="*-Info.plist" parent="NSCalendarsFullAccessUsageDescription">
+      <string>$CALENDAR_USAGE_DESCRIPTION</string>
+    </config-file>
     <!-- Usage description of the Contacts for iOS 6+, mandatory since iOS 10 -->
     <preference name="CONTACTS_USAGE_DESCRIPTION" default=" " />
     <config-file target="*-Info.plist" parent="NSContactsUsageDescription">


### PR DESCRIPTION
## Description
- Considering the changes introduced in `EventKit` for iOS 17, add the `requestFullAccessToEventWithCompletion:` method to trigger the alert to allow full access to the Calendar. This allows the plugin to behave similarly to the 16 version (and previous). 
- Considering that the methods use the same access grant closure, this was moved into a local variable that all callers can use. 
- The iOS 5 condition was removed as our current supported minimum version is higher than that one. 
- Add the `NSCalendarsFullAccessUsageDescription` info.plist key added by Apple for iOS 17. It uses the exact text set for 
`NSCalendarsUsageDescription`, keeping the same experience as before. 
- Remove the `SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO` macro as it's not used.

A sample app build was generated using MABS 10 beta to test the latest changes and can be fetched through https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=99acb7d7f10cdc2d461ac93290561aadae457eb6.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2726

## Type of changes
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Manual tests were done to validate this.

## Screenshots
![image](https://github.com/OutSystems/Calendar-PhoneGap-Plugin/assets/97543217/1f33a0c9-c0ca-40ce-bc1c-6f9d901626b3)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly