### PR TITLE
Fix ::: Android ::: Minor issue

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -360,6 +360,11 @@ public class Calendar extends CordovaPlugin {
       final JSONObject jsonFilter = args.getJSONObject(0);
       final JSONObject argOptionsObject = jsonFilter.getJSONObject("options");
 
+      if(jsonFilter.getLong("startTime") > jsonFilter.getLong("endTime")){
+        callback.error("The start date must be before the end date");
+        return;
+      }
+
       cordova.getThreadPool().execute(new Runnable() {
         @Override
         public void run() {


### PR DESCRIPTION
## Description

The Calendar plugin in Android was allowing creation of events via the phone's calendar app where the startDate was after the endDate. However on iOS an error was returned.

This PR fixes that issue on Android.

## Context


Mentioned in https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [X] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [X] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests

Test adding the "Test app - edit3" event in the Calendar Sample app - Should now give an error like it was already giving in iOS

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly