### PR TITLE
RMET-3656 Calendar Plugin - Add build action information

### DIFF
--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -1,0 +1,27 @@
+# Build Actions
+
+This folder contains .yaml files for configuring build actions to use in a plugin on ODC with Capacitor. The purpose of these build actions is to provide the same functionality as cordova hooks, but on a Capacitor shell.
+
+## Contents
+
+The file setBundleLocalizationsiOS.yaml contains one build actions:
+
+- iOS specific. Adds a `CFBundleLocalizations` entry with multiple language codes to the app's Info.plist file. These are necessary for the Calendar Plugin to work properly.
+
+## Outsystems' Usage
+
+1. Copy the build action yaml file (which can contain multiple build actions inside) into the ODC Plugin, placing them in "Data" -> "Resources" and set "Deploy Action" to "Deploy to Target Directory", with target directory empty.
+2. Update the Plugin's Extensibility configuration to use the build action.
+
+```json
+{
+    "buildConfigurations": {
+        "buildAction": {
+            "config": $resources.buildActionFileName.yaml,
+            "parameters": {
+                // parameters go here; if there are no parameters then the block can be ommited
+            }
+        }
+    }
+}
+```

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -4,7 +4,7 @@ This folder contains .yaml files for configuring build actions to use in a plugi
 
 ## Contents
 
-The file setBundleLocalizationsiOS.yaml contains one build actions:
+The file setBundleLocalizationsiOS.yaml contains one build action:
 
 - iOS specific. Adds a `CFBundleLocalizations` entry with multiple language codes to the app's Info.plist file. These are necessary for the Calendar Plugin to work properly.
 

--- a/build-actions/setBundleLocalizationsiOS.yaml
+++ b/build-actions/setBundleLocalizationsiOS.yaml
@@ -1,0 +1,12 @@
+platforms:
+  ios:
+    plist:
+      - replace: false
+        entries:
+          - CFBundleLocalizations:
+              - en
+              - de
+              - nl
+              - fr
+              - it
+              - pt-BR


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds a new `build-actions` folder to the repo, adding information about the build actions used in the OutSystems plugin, to make the plugin compatible with a Capacitor shell (MABS 12).

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3656

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [x] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly