### PR TITLE
RMET-4375 - iOS - Remove `NSContactsUsageDescription` from `Info.plist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-calendar",
-  "version": "5.1.3-OS9",
+  "version": "5.1.3-OS10",
   "description": "This plugin allows you to manipulate the native calendar.",
   "cordova": {
     "id": "cordova-plugin-calendar",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-calendar"
-    version="5.1.3-OS9">
+    version="5.1.3-OS10">
 
   <name>Calendar</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -59,11 +59,6 @@
     <config-file target="*-Info.plist" parent="NSCalendarsFullAccessUsageDescription">
       <string>$CALENDAR_USAGE_DESCRIPTION</string>
     </config-file>
-    <!-- Usage description of the Contacts for iOS 6+, mandatory since iOS 10 -->
-    <preference name="CONTACTS_USAGE_DESCRIPTION" default=" " />
-    <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
-      <string>$CONTACTS_USAGE_DESCRIPTION</string>
-    </config-file>
     <header-file src="src/ios/Calendar.h"/>
     <source-file src="src/ios/Calendar.m"/>
     <framework src="EventKit.framework"/>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Removes the `NSContactsUsageDescription` from being included in the `*-Info.plist` file through the `plugin.xml`.
- This had first been included in https://github.com/OutSystems/Calendar-PhoneGap-Plugin/pull/3, but after testing the plugin in all the iOS versions we support, and also considering that the plugin doesn't access Contacts directly, the usage description shouldn't be necessary.
    - What happens is that our plugin can create editable events using `EKEventEditViewController` which is a system-provided UI owned by the Calendar app, and in there the user can add Invitees to their event by searching through their contact list.
    - Also, when fetching events for the `FindEvent` feature, the attendees returned are tied to `EKEvent` from the Calendar iOS API and not the Contacts API.
    - In other words, it isn't the app using our plugin that accesses the contacts. Instead, this access is made by a system component, so no need for the usage description.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4375

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

[MABS 10 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=603daea89711fb35b36805c2e9bb0503eefabf8d&stg=dev)

[MABS 11 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=eac278e6d9f78565fcd91cea82b424119f377cd0&stg=dev)

MABS 12 build - use latest build in our ODC tenant.

Tested in iOS 26 and iOS 18 real devices. Tested from iOS 17 to iOS 14 in SauceLabs real devices.

### Testing instructions

Using our Calendar Sample App (O11 or ODC), create events in two ways:
- Create normal events right form the app (IsEditable = false), where you cannot set Invitees (contacts)
- Create editable events using `EKEventEditViewController` (IsEditable = true), where you can add invitees from your contacts.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly